### PR TITLE
Catch and handle _NET_WM_STATE atoms from PropertyChange events.

### DIFF
--- a/disp.c
+++ b/disp.c
@@ -31,7 +31,7 @@
 #include "ewmh.h"
 
 /*
- *    Dispatcher for main event loop.
+ *	Dispatcher for main event loop.
  */
 typedef struct Disp Disp;
 struct Disp {
@@ -670,6 +670,12 @@ property(XEvent * ev) {
 			cmapfocus(c);
 	} else if (e->atom == ewmh_atom[_NET_WM_STRUT]) {
 		ewmh_get_strut(c);
+	} else if (e->atom == ewmh_atom[_NET_WM_STATE]) {
+		// Received notice that client wants to change its state
+		//  update internal wstate tracking
+		ewmh_get_state(c);
+		// make changes requested
+		if (c->wstate.fullscreen == True) Client_EnterFullScreen(c);
 	}
 }
 

--- a/disp.c
+++ b/disp.c
@@ -673,9 +673,11 @@ property(XEvent * ev) {
 	} else if (e->atom == ewmh_atom[_NET_WM_STATE]) {
 		// Received notice that client wants to change its state
 		//  update internal wstate tracking
+		Bool wasFullscreen = c->wstate.fullscreen;
 		ewmh_get_state(c);
-		// make changes requested
-		if (c->wstate.fullscreen == True) Client_EnterFullScreen(c);
+		// make any changes requested
+		if (c->wstate.fullscreen == True && wasFullscreen == False) Client_EnterFullScreen(c);
+		else if (c->wstate.fullscreen == False && wasFullscreen == True) Client_ExitFullScreen(c);
 	}
 }
 


### PR DESCRIPTION
Some applications (e.g. snes9x-gtk) try to start in fullscreen by setting _NET_WM_STATE_FULLSCREEN property, rather than switching to fullscreen later by sending ChangeEvent messages.  lwm currently ignores wm_state events in the property change handler, so the application doesn't actually end up fullscreen: it's offset by (1,1) instead, and the top and left borders are visible.

This patch catches _NET_WM_STATE property change events, calls ewmh_get_state to update internal wstate values, and then triggers Client_EnterFullScreen or Client_ExitFullScreen if necessary.
