### PR TITLE
Make non-ASCII titles work

### DIFF
--- a/lwm.c
+++ b/lwm.c
@@ -87,6 +87,8 @@ main(int argc, char *argv[]) {
 
 	mode = wm_initialising;
 
+	setlocale(LC_ALL, "");
+
 	/* Open a connection to the X server. */
 	dpy = XOpenDisplay(NULL);
 	if (dpy == 0)

--- a/lwm.man
+++ b/lwm.man
@@ -70,7 +70,7 @@ exclusively by session managers.
 .SH RESOURCES
 \fILwm\fP understands the following X resources:
 .TP 12
-.B titlefont
+.B titleFont
 font used in window titles
 .TP 12
 .B popupFont

--- a/manage.c
+++ b/manage.c
@@ -493,21 +493,22 @@ getWindowName(Client *c) {
 	
 	was_nameless = (c->name == 0);
 	
-	if (ewmh_get_window_name(c) == False &&
-		XGetWindowProperty(dpy, c->window, _mozilla_url, 0L, 100L, False, AnyPropertyType, &actual_type, &format, &n, &extra, (unsigned char **) &name) == Success && name && *name != '\0' && n != 0) {
-		Client_Name(c, name, False);
-		XFree(name);
-	} else if (XGetWindowProperty(dpy, c->window, XA_WM_NAME, 0L, 100L, False, AnyPropertyType, &actual_type, &format, &n, &extra, (unsigned char **) &name) == Success && name && *name != '\0' && n != 0) {
-		/* That rather unpleasant condition is necessary because xwsh uses
-	 	* COMPOUND_TEXT rather than STRING for its WM_NAME property,
-	 	* and anonymous xwsh windows are annoying.
-	 	*/
-		if (actual_type == compound_text && memcmp(name, "\x1b\x28\x42", 3) == 0) {
-			Client_Name(c, name + 3, False);
-		} else {
+	if (ewmh_get_window_name(c) == False) {
+		if (XGetWindowProperty(dpy, c->window, _mozilla_url, 0L, 100L, False, AnyPropertyType, &actual_type, &format, &n, &extra, (unsigned char **) &name) == Success && name && *name != '\0' && n != 0) {
 			Client_Name(c, name, False);
+			XFree(name);
+		} else if (XGetWindowProperty(dpy, c->window, XA_WM_NAME, 0L, 100L, False, AnyPropertyType, &actual_type, &format, &n, &extra, (unsigned char **) &name) == Success && name && *name != '\0' && n != 0) {
+			/* That rather unpleasant condition is necessary because xwsh uses
+			* COMPOUND_TEXT rather than STRING for its WM_NAME property,
+			* and anonymous xwsh windows are annoying.
+			*/
+			if (actual_type == compound_text && memcmp(name, "\x1b\x28\x42", 3) == 0) {
+				Client_Name(c, name + 3, False);
+			} else {
+				Client_Name(c, name, False);
+			}
+			XFree(name);
 		}
-		XFree(name);
 	}
 	
 	if (!was_nameless)


### PR DESCRIPTION
Non-ASCII titles don't work because, firstly, since a2e38cd the locale is fixed to default C and therefore font selection and string drawing is limited to ASCII. And secondly, because current logic for getting the window title is to get EWMH title from `_NET_WM_NAME` first, and when it _succeeds_ (sic) to try using `WM_NAME`; but the latter might come in various forms and lwm doesn't try to parse it and just sets `is_utf8` to `False`. Most of my windows have both so after successfully acquiring UTF-8 tittle it immediately gets overwritten with garbage.

This brings the setlocale back and changes title logic not to try other methods if EWMH succeeds, effectively making UTF-8 titles work as intended.
